### PR TITLE
dirty hack

### DIFF
--- a/pkg/config/dynamic/tcp_config.go
+++ b/pkg/config/dynamic/tcp_config.go
@@ -21,6 +21,7 @@ type TCPConfiguration struct {
 type TCPService struct {
 	LoadBalancer *TCPServersLoadBalancer `json:"loadBalancer,omitempty" toml:"loadBalancer,omitempty" yaml:"loadBalancer,omitempty" export:"true"`
 	Weighted     *TCPWeightedRoundRobin  `json:"weighted,omitempty" toml:"weighted,omitempty" yaml:"weighted,omitempty" label:"-" export:"true"`
+	StartTLS     string                  `json:"startTLS,omitempty" toml:"startTLS,omitempty" yaml:"startTLS,omitempty" export:"true"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/provider/kubernetes/crd/kubernetes_tcp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_tcp.go
@@ -187,6 +187,7 @@ func (p *Provider) createLoadBalancerServerTCP(client Client, parentNamespace st
 		LoadBalancer: &dynamic.TCPServersLoadBalancer{
 			Servers: servers,
 		},
+		StartTLS: service.StartTLS,
 	}
 
 	if service.ProxyProtocol != nil {

--- a/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroutetcp.go
+++ b/pkg/provider/kubernetes/crd/traefik/v1alpha1/ingressroutetcp.go
@@ -51,6 +51,7 @@ type ServiceTCP struct {
 	Weight           *int                   `json:"weight,omitempty"`
 	TerminationDelay *int                   `json:"terminationDelay,omitempty"`
 	ProxyProtocol    *dynamic.ProxyProtocol `json:"proxyProtocol,omitempty"`
+	StartTLS         string                 `json:"startTLS,omitempty"`
 }
 
 // +genclient

--- a/pkg/server/service/tcp/service.go
+++ b/pkg/server/service/tcp/service.go
@@ -59,7 +59,7 @@ func (m *Manager) BuildTCP(rootCtx context.Context, serviceName string) (tcp.Han
 				continue
 			}
 
-			handler, err := tcp.NewProxy(server.Address, duration, conf.LoadBalancer.ProxyProtocol)
+			handler, err := tcp.NewProxy(server.Address, duration, conf.LoadBalancer.ProxyProtocol, conf.StartTLS)
 			if err != nil {
 				logger.Errorf("In service %q server %q: %v", serviceQualifiedName, server.Address, err)
 				continue

--- a/pkg/tcp/proxy_test.go
+++ b/pkg/tcp/proxy_test.go
@@ -54,7 +54,7 @@ func TestCloseWrite(t *testing.T) {
 	_, port, err := net.SplitHostPort(backendListener.Addr().String())
 	require.NoError(t, err)
 
-	proxy, err := NewProxy(":"+port, 10*time.Millisecond, nil)
+	proxy, err := NewProxy(":"+port, 10*time.Millisecond, nil, "")
 	require.NoError(t, err)
 
 	proxyListener, err := net.Listen("tcp", ":0")
@@ -133,7 +133,7 @@ func TestProxyProtocol(t *testing.T) {
 			_, port, err := net.SplitHostPort(proxyBackendListener.Addr().String())
 			require.NoError(t, err)
 
-			proxy, err := NewProxy(":"+port, 10*time.Millisecond, &dynamic.ProxyProtocol{Version: test.version})
+			proxy, err := NewProxy(":"+port, 10*time.Millisecond, &dynamic.ProxyProtocol{Version: test.version}, "")
 			require.NoError(t, err)
 
 			proxyListener, err := net.Listen("tcp", ":0")
@@ -194,7 +194,7 @@ func TestLookupAddress(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			proxy, err := NewProxy(test.address, 10*time.Millisecond, nil)
+			proxy, err := NewProxy(test.address, 10*time.Millisecond, nil, "")
 			require.NoError(t, err)
 
 			require.NotNil(t, proxy.target)

--- a/pkg/tcp/starttls.go
+++ b/pkg/tcp/starttls.go
@@ -1,0 +1,96 @@
+package tcp
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/traefik/traefik/v2/pkg/log"
+)
+
+var (
+	postgresStartTLSMsg   = []byte{0, 0, 0, 8, 4, 210, 22, 47} // int32(8) + int32(80877103)
+	postgresStartTLSReply = []byte{83}                         // S
+)
+
+// invokeStartTLSPostgresHandshake performs the postgres StartTLS
+// handshake (client side). It sends the postgresStartTLSMsg
+// and checkes if the server response matches the expected value.
+// It returns an error on read/write failures on the connection
+// or if the server response doesn't match.
+func invokeStartTLSPostgresHandshake(conn WriteCloser) error {
+	log.Debug("Starttls handshake with target")
+
+	_, err := conn.Write(postgresStartTLSMsg)
+	if err != nil {
+		return err
+	}
+
+	b := make([]byte, 1)
+	_, err = conn.Read(b)
+	if err != nil {
+		return err
+	}
+
+	if b[0] != postgresStartTLSReply[0] {
+		return fmt.Errorf("Unexpected postgres starttls handshake response got %v want 'S' ", b)
+	}
+	return nil
+}
+
+// handleStartTLSHandshake performs a StartTLS Handshake (server side)
+// It peeks some into some bytes of conn and
+// tries to find out if the client performs a StartTLS handshake.
+// If the client request does contain a StartTLS handshake signature
+// the handshake is performed. After this step the client will
+// start a TLS session.
+// If no StartTLS signature is found the bytes of the connection
+// are unmodified.
+// In any case the caller must use the returned WriteCloser for
+// further read/write operations.
+// An error is retured if reading or writing to the WriteCloser fails.
+//
+// BEWARE: currently only postgres startTLS handshake flavor is currently implemented.
+func handleStartTLSHandshake(conn WriteCloser) (WriteCloser, error) {
+	startTLSConn := newStartTLSConn(conn)
+
+	buf, err := startTLSConn.Peek(len(postgresStartTLSMsg))
+	if err != nil {
+		if err != io.EOF {
+			log.WithoutContext().Errorf("Error on starttls handshake: %v", err)
+		}
+		return startTLSConn, err
+	}
+
+	if !bytes.Equal(buf, postgresStartTLSMsg) {
+		return startTLSConn, nil
+	}
+
+	// consume the bytes that we just peeked so far..
+	startTLSConn.Read(buf)
+
+	_, err = conn.Write(postgresStartTLSReply)
+	if err != nil {
+		return startTLSConn, err
+	}
+
+	return startTLSConn, nil
+}
+
+type startTLSConn struct {
+	br *bufio.Reader
+	WriteCloser
+}
+
+func newStartTLSConn(conn WriteCloser) startTLSConn {
+	return startTLSConn{bufio.NewReader(conn), conn}
+}
+
+func (s startTLSConn) Peek(n int) ([]byte, error) {
+	return s.br.Peek(n)
+}
+
+func (s startTLSConn) Read(p []byte) (int, error) {
+	return s.br.Read(p)
+}

--- a/traefik.dyn.toml
+++ b/traefik.dyn.toml
@@ -1,0 +1,25 @@
+
+# Dynamic configuration
+[tcp.routers]
+  [tcp.routers.Router-1]
+    rule = "HostSNI(`postgres.sni.rx-c16.app.corpintra.net`)"
+    service = "cockroach"
+    [tcp.routers.Router-1.tls]
+      passthrough = true
+  [tcp.routers.Router-2]
+    rule = "HostSNI(`mongo-0.mongo`)"
+    service = "mongo"
+    [tcp.routers.Router-2.tls]
+      passthrough = true
+
+## Dynamic configuration
+[tcp.services]
+  [tcp.services.cockroach]
+    startTLS = "postgres"
+  [tcp.services.cockroach.loadBalancer]
+    [[tcp.services.cockroach.loadBalancer.servers]]
+      address = "localhost:64000"
+
+  [tcp.services.mongo.loadBalancer]
+    [[tcp.services.mongo.loadBalancer.servers]]
+      address = "localhost:27017"

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -10,8 +10,8 @@
 # Global configuration
 ################################################################
 [global]
-  checkNewVersion = true
-  sendAnonymousUsage = true
+checkNewVersion = true
+sendAnonymousUsage = true
 
 ################################################################
 # Entrypoints configuration
@@ -22,11 +22,14 @@
 # Optional
 # Default:
 [entryPoints]
-  [entryPoints.web]
-    address = ":80"
+[entryPoints.traefik]
+address = ":9000"
 
-  [entryPoints.websecure]
-    address = ":443"
+[entryPoints.web]
+address = ":8000"
+
+[entryPoints.websecure]
+address = ":8443"
 
 ################################################################
 # Traefik logs configuration
@@ -39,27 +42,27 @@
 #
 [log]
 
-  # Log level
-  #
-  # Optional
-  # Default: "ERROR"
-  #
-  # level = "DEBUG"
+# Log level
+#
+# Optional
+# Default: "ERROR"
+#
+level = "DEBUG"
 
-  # Sets the filepath for the traefik log. If not specified, stdout will be used.
-  # Intermediate directories are created if necessary.
-  #
-  # Optional
-  # Default: os.Stdout
-  #
-  # filePath = "log/traefik.log"
+# Sets the filepath for the traefik log. If not specified, stdout will be used.
+# Intermediate directories are created if necessary.
+#
+# Optional
+# Default: os.Stdout
+#
+# filePath = "log/traefik.log"
 
-  # Format is either "json" or "common".
-  #
-  # Optional
-  # Default: "common"
-  #
-  # format = "json"
+# Format is either "json" or "common".
+#
+# Optional
+# Default: "common"
+#
+# format = "json"
 
 ################################################################
 # Access logs configuration
@@ -73,20 +76,20 @@
 #
 # [accessLog]
 
-  # Sets the file path for the access log. If not specified, stdout will be used.
-  # Intermediate directories are created if necessary.
-  #
-  # Optional
-  # Default: os.Stdout
-  #
-  # filePath = "/path/to/log/log.txt"
+# Sets the file path for the access log. If not specified, stdout will be used.
+# Intermediate directories are created if necessary.
+#
+# Optional
+# Default: os.Stdout
+#
+# filePath = "/path/to/log/log.txt"
 
-  # Format is either "json" or "common".
-  #
-  # Optional
-  # Default: "common"
-  #
-  # format = "json"
+# Format is either "json" or "common".
+#
+# Optional
+# Default: "common"
+#
+# format = "json"
 
 ################################################################
 # API and dashboard configuration
@@ -95,19 +98,19 @@
 # Enable API and dashboard
 [api]
 
-  # Enable the API in insecure mode
-  #
-  # Optional
-  # Default: false
-  #
-  # insecure = true
+# Enable the API in insecure mode
+#
+# Optional
+# Default: false
+#
+# insecure = true
 
-  # Enabled Dashboard
-  #
-  # Optional
-  # Default: true
-  #
-  # dashboard = false
+# Enabled Dashboard
+#
+# Optional
+# Default: true
+#
+# dashboard = false
 
 ################################################################
 # Ping configuration
@@ -116,12 +119,12 @@
 # Enable ping
 [ping]
 
-  # Name of the related entry point
-  #
-  # Optional
-  # Default: "traefik"
-  #
-  # entryPoint = "traefik"
+# Name of the related entry point
+#
+# Optional
+# Default: "traefik"
+#
+# entryPoint = "traefik"
 
 ################################################################
 # Docker configuration backend
@@ -130,23 +133,26 @@
 # Enable Docker configuration backend
 [providers.docker]
 
-  # Docker server endpoint. Can be a tcp or a unix socket endpoint.
-  #
-  # Required
-  # Default: "unix:///var/run/docker.sock"
-  #
-  # endpoint = "tcp://10.10.10.10:2375"
+# Docker server endpoint. Can be a tcp or a unix socket endpoint.
+#
+# Required
+# Default: "unix:///var/run/docker.sock"
+#
+# endpoint = "tcp://10.10.10.10:2375"
 
-  # Default host rule.
-  #
-  # Optional
-  # Default: "Host(`{{ normalize .Name }}`)"
-  #
-  # defaultRule = "Host(`{{ normalize .Name }}.docker.localhost`)"
+# Default host rule.
+#
+# Optional
+# Default: "Host(`{{ normalize .Name }}`)"
+#
+# defaultRule = "Host(`{{ normalize .Name }}.docker.localhost`)"
 
-  # Expose containers by default in traefik
-  #
-  # Optional
-  # Default: true
-  #
-  # exposedByDefault = false
+# Expose containers by default in traefik
+#
+# Optional
+# Default: true
+#
+# exposedByDefaul[providers]
+
+[providers.file]
+filename = "traefik.dyn.toml"


### PR DESCRIPTION
What does this PR do?

This adds starttls support which allows to reverse proxy postgres connections through traefik (via SNI).
Motivation
Context:

We have a number of PostgreSQL databases running inside our kubernetes cluster.
All database instances are accessed through traefik via a single IP address. In order to
access the right PostgreSQL instances from the clients we want to use different subdomains.
One subdomain should be the target address of a specific PostgreSQL instance and we want to
route to it via the SNI (server name indication in TLS header).
This approach seems to be the only possible solution in our setup. We don't have any other information
to identify the target PostgreSQL instance from a client request.
Problem:

PostgreSQL performs a StartTLS handshake before sending any TLS header. Since traefik doesn't perform
this handshake no TLS header is sent and hence traefik cannot extract the target server name.
Idea:

We propose the following steps:

traefik performs StartTLS handshake with client
client now sends TLS header
traefik extracts SNI
traefik performs StartTLS handshake with server
traefik routes connection from client to target PostgreSQL instance
More

Added/updated tests

    Added/updated documentation

Additional Notes

Other starttls flavors might be added in future.

Michael Kuhnt michael.kuhnt@daimler.com Daimler TSS GmbH (Imprint)
